### PR TITLE
Fix further warnings in headers

### DIFF
--- a/src/fontstash.h
+++ b/src/fontstash.h
@@ -916,7 +916,7 @@ int fonsAddFont(FONScontext* stash, const char* name, const char* path)
 	readed = fread(data, 1, dataSize, fp);
 	fclose(fp);
 	fp = 0;
-	if (readed != dataSize) goto error;
+        if (readed != (size_t)dataSize) goto error;
 
 	return fonsAddFontMem(stash, name, data, dataSize, 1);
 


### PR DESCRIPTION
~~Second round of fixes. Among the others, it is possible to mention:~~

~~1. `misleading-indentation`** - (`this 'for' clause does not guard...`)~~
~~2. `shift-negative-value` - (`left shift of negative value`)~~
~~3.  `implicit-fallthrough` - (`this statement may fall through`)~~

Fix a further warning as found in `fontstash.h`.